### PR TITLE
Pin requirements for PySNMP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Twisted
 PyYaml
 protobuf
 construct
-pysnmp
+pysnmp==4.2.5


### PR DESCRIPTION
Does what it says on the tin. If we don't do this SNMP checks can fail with the following stack trace:

```
File "/usr/local/lib/python2.7/dist-packages/tensor/sources/snmp.py", line 20, in <module>
    from pysnmp.entity.rfc3413.twisted import cmdgen
ImportError: No module named twisted
```