### PR TITLE
Adding ability to add "Attributes"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tensor",
-    version='0.3.4',
+    version='0.3.5',
     url='http://github.com/calston/tensor',
     license='MIT',
     description="A Twisted based monitoring agent for Riemann",

--- a/tensor/objects.py
+++ b/tensor/objects.py
@@ -21,7 +21,7 @@ class Event(object):
     :param tags: List of tag strings
     :param hostname: Hostname for the event (defaults to system fqdn)
     :param aggregation: Aggregation function
-    :param attributes: Attributes for this event
+    :param attributes: A dictionary of key/value attributes for this event
     :param evtime: Event timestamp override
     """
     def __init__(
@@ -43,7 +43,7 @@ class Event(object):
         self.metric = metric
         self.ttl = ttl
         self.tags = tags if tags is not None else []
-        self.attributes = attributes if attributes is not None else dict()
+        self.attributes = attributes
         self.aggregation = aggregation
         self._type = type
         

--- a/tensor/objects.py
+++ b/tensor/objects.py
@@ -17,19 +17,33 @@ class Event(object):
     :param service: The service name for this event
     :param description: A description for the event, ie. "My house is on fire!"
     :param metric: int or float metric for this event
+    :param ttl: TTL (time-to-live) for this event
     :param tags: List of tag strings
     :param hostname: Hostname for the event (defaults to system fqdn)
     :param aggregation: Aggregation function
+    :param attributes: Attributes for this event
     :param evtime: Event timestamp override
     """
-    def __init__(self, state, service, description, metric, ttl, tags=[],
-            hostname=None, aggregation=None, evtime=None, type='riemann'):
+    def __init__(
+            self,
+            state,
+            service,
+            description,
+            metric,
+            ttl,
+            tags=None,
+            hostname=None,
+            aggregation=None,
+            evtime=None,
+            attributes=None,
+            type='riemann'):
         self.state = state
         self.service = service
         self.description = description
         self.metric = metric
         self.ttl = ttl
-        self.tags = tags
+        self.tags = tags if tags is not None else []
+        self.attributes = attributes if attributes is not None else dict()
         self.aggregation = aggregation
         self._type = type
         

--- a/tensor/protocol/riemann.py
+++ b/tensor/protocol/riemann.py
@@ -31,7 +31,7 @@ class RiemannProtobufMixin(object):
                 pbevent.metric_f = float(event.metric)
         if event.attributes is not None:
             for key, value in event.attributes.items():
-                attribute = event.attributes.add()
+                attribute = pbevent.attributes.add()
                 attribute.key, attribute.value = key, value
 
         return pbevent

--- a/tensor/protocol/riemann.py
+++ b/tensor/protocol/riemann.py
@@ -29,6 +29,10 @@ class RiemannProtobufMixin(object):
             else:
                 pbevent.metric_d = float(event.metric)
                 pbevent.metric_f = float(event.metric)
+        if event.attributes is not None:
+            for key, value in event.attributes.items():
+                attribute = event.attributes.add()
+                attribute.key, attribute.value = key, value
 
         return pbevent
 

--- a/tensor/tests/test_tensor.py
+++ b/tensor/tests/test_tensor.py
@@ -25,6 +25,15 @@ class Tests(unittest.TestCase):
         # Well, I guess we'll just assume this is right
         message = proto.encodeMessage([event])
 
+    def test_riemann_protobuf_with_attributes(self):
+        proto = riemann.RiemannProtocol()
+
+        event = Event('ok', 'sky', 'Sky has not fallen', 1.0, 60.0,
+                      attributes={"chicken": "little"})
+
+        # Well, I guess we'll just assume this is right
+        message = proto.encodeMessage([event])
+
     @defer.inlineCallbacks
     def test_tcp_riemann(self):
 

--- a/tensor/tests/test_tensor.py
+++ b/tensor/tests/test_tensor.py
@@ -3,6 +3,7 @@ from twisted.trial import unittest
 from twisted.internet import defer, reactor, error
 from twisted.internet.endpoints import TCP4ClientEndpoint, connectProtocol
 
+from tensor.ihateprotobuf.proto_pb2 import Attribute
 from tensor.protocol import riemann
 
 from tensor.objects import Event
@@ -31,8 +32,12 @@ class Tests(unittest.TestCase):
         event = Event('ok', 'sky', 'Sky has not fallen', 1.0, 60.0,
                       attributes={"chicken": "little"})
 
-        # Well, I guess we'll just assume this is right
         message = proto.encodeMessage([event])
+        self.assertEqual(len(message.events), 1)
+        attrs = message.events[0].attributes
+        self.assertEqual(len(attrs), 1)
+        self.assertEqual(attrs[0].key, "chicken")
+        self.assertEqual(attrs[0].value, "little")
 
     @defer.inlineCallbacks
     def test_tcp_riemann(self):

--- a/tensor/tests/test_tensor.py
+++ b/tensor/tests/test_tensor.py
@@ -3,7 +3,6 @@ from twisted.trial import unittest
 from twisted.internet import defer, reactor, error
 from twisted.internet.endpoints import TCP4ClientEndpoint, connectProtocol
 
-from tensor.ihateprotobuf.proto_pb2 import Attribute
 from tensor.protocol import riemann
 
 from tensor.objects import Event

--- a/tensor/tests/test_tensor.py
+++ b/tensor/tests/test_tensor.py
@@ -32,9 +32,8 @@ class Tests(unittest.TestCase):
         event = Event('ok', 'sky', 'Sky has not fallen', 1.0, 60.0,
                       attributes={"chicken": "little"})
 
-        message = proto.encodeMessage([event])
-        self.assertEqual(len(message.events), 1)
-        attrs = message.events[0].attributes
+        e = proto.encodeEvent(event)
+        attrs = e.attributes
         self.assertEqual(len(attrs), 1)
         self.assertEqual(attrs[0].key, "chicken")
         self.assertEqual(attrs[0].value, "little")


### PR DESCRIPTION
@calston 

Riemann events support Attributes, so I'm adding that capability in Tensor.

I apologize about the gratuitous method signature reformatting; I just thought it was getting a little unwieldy.

I've also added some missing arguments to the docstring. Let me know if this looks okay!

Usage would be from a `Source`:

```python
event = self.createEvent(
    'ok',
    "{} since {} was modified".format(touch_time, filename),
    file_age_in_sec,
    prefix="age",
    attributes={"location": "datacenter1"})
```

