### PR TITLE
Allow `attributes` value in Tensor Sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tensor",
-    version='0.3.5',
+    version='0.3.6',
     url='http://github.com/calston/tensor',
     license='MIT',
     description="A Twisted based monitoring agent for Riemann",

--- a/tensor/objects.py
+++ b/tensor/objects.py
@@ -137,7 +137,7 @@ class Source(object):
             self.tags = [tag.strip() for tag in config['tags'].split(',')]
         else:
             self.tags = []
-        if 'attributes' in config:
+        if 'attributes' in config and isinstance(config['attributes'], dict):
             self.attributes = config['attributes']
 
         self.hostname = config.get('hostname')

--- a/tensor/objects.py
+++ b/tensor/objects.py
@@ -128,6 +128,7 @@ class Source(object):
         self.config = config
         self.t = task.LoopingCall(self.tick)
         self.td = None
+        self.attributes = None
 
         self.service = config['service']
         self.inter = float(config['interval'])
@@ -137,8 +138,10 @@ class Source(object):
             self.tags = [tag.strip() for tag in config['tags'].split(',')]
         else:
             self.tags = []
-        if 'attributes' in config and isinstance(config['attributes'], dict):
-            self.attributes = config['attributes']
+
+        attributes = config.get("attributes")
+        if isinstance(attributes, dict):
+            self.attributes = attributes
 
         self.hostname = config.get('hostname')
         if self.hostname is None:

--- a/tensor/objects.py
+++ b/tensor/objects.py
@@ -137,6 +137,8 @@ class Source(object):
             self.tags = [tag.strip() for tag in config['tags'].split(',')]
         else:
             self.tags = []
+        if 'attributes' in config:
+            self.attributes = config['attributes']
 
         self.hostname = config.get('hostname')
         if self.hostname is None:
@@ -201,7 +203,7 @@ class Source(object):
 
         return Event(state, service_name, description, metric, self.ttl,
             hostname=hostname or self.hostname, aggregation=aggregation,
-            evtime=evtime, tags=self.tags
+            evtime=evtime, tags=self.tags, attributes=self.attributes
         )
 
     def createLog(self, type, data, evtime=None, hostname=None):


### PR DESCRIPTION
@calston 

Hey there, I don't know how this escaped me; some checks might need to share a `Source` but have different `attribute`s defined. This patch allows the user to specify arbitrary attributes per check:

```yaml
# ... etc ...
sources:

  - service: cpu
    source: tensor.sources.linux.basic.CPU
    attributes:
      key1: val1
      key2: val2

  - service: disk_free
    source: tensor.sources.linux.basic.DiskFree
    attributes:
      key1: val3
```

Thanks, and sorry for leaving this out of the last PR!